### PR TITLE
Add tiny2313 support

### DIFF
--- a/arch/avr/timer.c
+++ b/arch/avr/timer.c
@@ -31,6 +31,11 @@ void arch_timer_init(void (*timer_handler)(void))
 	arch_timer_handler = timer_handler;
 
 	TCCR0B |= (1 << CS01) | (1 << CS00); /* prescaler 64 */
+
+#ifdef AVR_COMMON_TIMSK
+	TIMSK |= (1 << TOIE0);
+#else
 	TIMSK0 |= (1 << TOIE0); /* Enable TIMER0 overflow interrupt */
+#endif
 }
 

--- a/board/tiny2313/board.h
+++ b/board/tiny2313/board.h
@@ -1,0 +1,29 @@
+/*
+ * Part of the Conic project - robot arm controller
+ *
+ * ATTiny2313 sample board support
+ *
+ * See LICENSE.md for licensing information
+ * Roman Luitko, 2020
+ */
+
+#ifndef BOARD_TINY2313_H
+#define BOARD_TINY2313_H
+
+/* Servos */
+#define BOARD_SERVO_1_PORT	GPIOB
+#define BOARD_SERVO_2_PORT	GPIOB
+#define BOARD_SERVO_3_PORT	GPIOB
+#define BOARD_SERVO_4_PORT	GPIOB
+#define BOARD_SERVO_5_PORT	GPIOB
+#define BOARD_SERVO_6_PORT	GPIOB
+
+#define BOARD_SERVO_1_PIN	0
+#define BOARD_SERVO_2_PIN	1
+#define BOARD_SERVO_3_PIN	2
+#define BOARD_SERVO_4_PIN	3
+#define BOARD_SERVO_5_PIN	4
+#define BOARD_SERVO_6_PIN	5
+
+#endif
+

--- a/board/tiny2313/board.mk
+++ b/board/tiny2313/board.mk
@@ -1,0 +1,8 @@
+MCU		:= attiny_x313
+AVR_MMCU	:= attiny2313
+AVR_FCPU	:= 16000000
+
+FLASH_CHIP	:= attiny2313
+
+objects	+= $(call my-dir)tiny2313.o
+

--- a/board/tiny2313/tiny2313.c
+++ b/board/tiny2313/tiny2313.c
@@ -1,0 +1,27 @@
+/*
+ * Part of the Conic project - robot arm controller
+ *
+ * ATTiny2313 sample board support
+ *
+ * See LICENSE.md for licensing information
+ * Roman Luitko, 2020
+ */
+
+#include <board/common.h>
+#include <mcu/common.h>
+
+void board_led_on(void)
+{
+	/* Not implemented */
+}
+
+void board_led_off(void)
+{
+	/* Not implemented */
+}
+
+void board_init(void)
+{
+	uart_init(UART_BAUD_115200);
+}
+

--- a/mcu/attiny_x313/gpio.c
+++ b/mcu/attiny_x313/gpio.c
@@ -1,0 +1,41 @@
+/*
+ * Part of the Conic project - robot arm controller
+ *
+ * ATtiny2313/4313 GPIO.
+ *
+ * See LICENSE.md for licensing information
+ * Roman Luitko, 2020
+ */
+
+#include <mcu/common.h>
+
+bool gpio_get(struct gpio *bank, uint8_t pin)
+{
+	return !!(bank->PIN & (1 << pin));
+}
+
+void gpio_set(struct gpio *bank, uint8_t pin)
+{
+	bank->PORT |= (1 << pin);
+}
+
+void gpio_clr(struct gpio *bank, uint8_t pin)
+{
+	bank->PORT &= ~(1 << pin);
+}
+
+void gpio_toggle(struct gpio *bank, uint8_t pin)
+{
+	bank->PORT ^= (1 << pin);
+}
+
+void gpio_in(struct gpio *bank, uint8_t pin)
+{
+	bank->DDR &= ~(1 << pin);
+}
+
+void gpio_out(struct gpio *bank, uint8_t pin)
+{
+	bank->DDR |= (1 << pin);
+}
+

--- a/mcu/attiny_x313/gpio.h
+++ b/mcu/attiny_x313/gpio.h
@@ -1,0 +1,31 @@
+/*
+ * Part of the Conic project - robot arm controller
+ *
+ * ATtiny2313/4313 GPIO.
+ *
+ * See LICENSE.md for licensing information
+ * Roman Luitko, 2020
+ */
+
+#ifndef MCU_ATTINY_X313_GPIO_H
+#define MCU_ATTINY_X313_GPIO_H
+
+#include <stdint.h>
+
+/* Not sure about this SFR fuzz but that ones with SFR offset (0x20) */
+#define GPIOB_BASE	0x23
+#define GPIOC_BASE	0x26
+#define GPIOD_BASE	0x29
+
+struct gpio {
+	volatile uint8_t PIN;
+	volatile uint8_t DDR;
+	volatile uint8_t PORT;
+};
+
+#define GPIOB	((struct gpio*)GPIOB_BASE)
+#define GPIOC	((struct gpio*)GPIOC_BASE)
+#define GPIOD	((struct gpio*)GPIOD_BASE)
+
+#endif
+

--- a/mcu/attiny_x313/gpio.h
+++ b/mcu/attiny_x313/gpio.h
@@ -13,9 +13,9 @@
 #include <stdint.h>
 
 /* Not sure about this SFR fuzz but that ones with SFR offset (0x20) */
-#define GPIOB_BASE	0x23
-#define GPIOC_BASE	0x26
-#define GPIOD_BASE	0x29
+#define GPIOD_BASE	0x30
+#define GPIOB_BASE	0x36
+#define GPIOA_BASE	0x39
 
 struct gpio {
 	volatile uint8_t PIN;
@@ -23,9 +23,9 @@ struct gpio {
 	volatile uint8_t PORT;
 };
 
-#define GPIOB	((struct gpio*)GPIOB_BASE)
-#define GPIOC	((struct gpio*)GPIOC_BASE)
 #define GPIOD	((struct gpio*)GPIOD_BASE)
+#define GPIOB	((struct gpio*)GPIOB_BASE)
+#define GPIOA	((struct gpio*)GPIOA_BASE)
 
 #endif
 

--- a/mcu/attiny_x313/mcu.h
+++ b/mcu/attiny_x313/mcu.h
@@ -1,0 +1,12 @@
+/*
+ * Part of the Conic project - robot arm controller
+ *
+ * Attiny2313/4313 support.
+ *
+ * See LICENSE.md for licensing information
+ * Roman Luitko, 2020
+ */
+
+#include <mcu/attiny_x313/uart.h>
+#include <mcu/attiny_x313/gpio.h>
+

--- a/mcu/attiny_x313/mcu.mk
+++ b/mcu/attiny_x313/mcu.mk
@@ -1,0 +1,11 @@
+ARCH		:= avr
+
+this-dir	:= $(call my-dir)
+
+objects += \
+	$(this-dir)uart.o \
+	$(this-dir)timer.o \
+	$(this-dir)gpio.o
+
+CFLAGS += -DAVR_COMMON_TIMSK
+

--- a/mcu/attiny_x313/timer.c
+++ b/mcu/attiny_x313/timer.c
@@ -1,0 +1,123 @@
+/*
+ * Part of the Conic project - robot arm controller
+ *
+ * ATtiny2313/4313 timer.
+ *
+ * We use TIMER1 here. Compare channel B (OCR1B) is used as actual compare
+ * register and overflows are 'emulated' with channel A (OCR1A)
+ *
+ * See LICENSE.md for licensing information
+ * Roman Luitko, 2020
+ */
+
+#include <arch/common.h>
+#include <mcu/common.h>
+#include <avr/io.h>
+#include <avr/interrupt.h>
+
+/*
+ * AVR timers are stupid. Available dividers are 1, 8, 64, 256 and 1024,
+ * and it's impossible to clearly get 1 microsecond tick on stock
+ * 16 Mhz Arduino without dividing compare channel values
+ */
+
+#define TIMER_PRESCALER_1	((0 << CS12) | (0 << CS11) | (1 << CS10))
+#define TIMER_PRESCALER_8	((0 << CS12) | (1 << CS11) | (0 << CS10))
+#define TIMER_PRESCALER_64	((0 << CS12) | (1 << CS11) | (1 << CS10))
+#define TIMER_PRESCALER_256	((1 << CS12) | (0 << CS11) | (0 << CS10))
+#define TIMER_PRESCALER_1024	((1 << CS12) | (0 << CS11) | (1 << CS10))
+#define TIMER_PRESCALER_MASK	((1 << CS12) | (1 << CS11) | (1 << CS10))
+
+/* Arduino UNO / Mega clocked from external crystal */
+#if F_CPU == 16000000UL
+	#define OCR_DIVIDER		4
+	#define TIMER_PRESCALER		TIMER_PRESCALER_64
+
+/* AVR clocked from internal 8 Mhz RC oscillator, or Arduino pro mini */
+#elif F_CPU == 8000000UL
+	#define OCR_DIVIDER		1
+	#define TIMER_PRESCALER		TIMER_PRESCALER_8
+
+/* AVR clocked from internal 8 Mhz RC oscillator divided by 8 */
+#elif F_CPU == 1000000UL
+	#define OCR_DIVIDER		1
+	#define TIMER_PRESCALER		TIMER_PRESCALER_1
+
+#else
+	#error "this F_CPU is not supported by timer.c. FIXME"
+#endif
+
+static void (*timer_compare_callback)(void);
+static void (*timer_overflow_callback)(void);
+
+/* Timer clears on compare A. This is our overflow */
+ISR(TIMER1_COMPA_vect)
+{
+	timer_overflow_callback();
+}
+
+ISR(TIMER1_COMPB_vect)
+{
+	timer_compare_callback();
+}
+
+void timer_on_compare(void (*compare_cb)(void))
+{
+	if (!compare_cb) {
+		/* Disable TIMER1 compare B interrupt */
+		TIMSK &= ~(1 << OCIE1B);
+	} else {
+		/* Enable TIMER1 compare B interrupt */
+		TIMSK |= (1 << OCIE1B);
+	}
+
+	timer_compare_callback = compare_cb;
+}
+
+void timer_on_overflow(void (*overflow_cb)(void))
+{
+	/* Overflows are 'emulated' via compare channel A */
+	if (!overflow_cb) {
+		/* Disable TIMER1 compare A interrupt */
+		TIMSK &= ~(1 << OCIE1A);
+	} else {
+		/* Enable TIMER1 compare A interrupt */
+		TIMSK |= (1 << OCIE1A);
+	}
+
+	timer_overflow_callback = overflow_cb;
+}
+
+/*
+ * Note that OCR1B and OCR1A are 16-bits registers and writes to them are not
+ * atomic, and user should ensure that this functions are not used concurrently
+ * from interrupt and main thread. FIXME
+ */
+void timer_set_compare(uint16_t compare)
+{
+	OCR1B = compare / OCR_DIVIDER;
+}
+
+void timer_set_overflow(uint16_t overflow)
+{
+	OCR1A = overflow / OCR_DIVIDER;
+}
+
+void timer_start(void)
+{
+	TCCR1B |= TIMER_PRESCALER;
+}
+
+void timer_stop(void)
+{
+	/* No prescaler - timer stopped */
+	TCCR1B &= ~TIMER_PRESCALER_MASK;
+}
+
+void timer_init(void)
+{
+	/* Clear timer on OCR1A compare match (CTC) */
+	TCCR1A = 0;
+	TCCR1B = (1 << WGM12);
+}
+

--- a/mcu/attiny_x313/uart.c
+++ b/mcu/attiny_x313/uart.c
@@ -1,0 +1,59 @@
+/*
+ * Part of the Conic project - robot arm controller
+ *
+ * ATtiny2313/4313 UART.
+ * This chips equipped with a single uart on pins PD1 -> TXD, PD0 -> RXD
+ *
+ * See LICENSE.md for licensing information
+ * Roman Luitko, 2020
+ */
+
+#include <avr/io.h>
+#include <avr/interrupt.h>
+#include <mcu/common.h>
+
+static void (*uart_receive_callback)(uint8_t byte);
+
+ISR(USART_RX_vect)
+{
+	volatile uint8_t byte;
+
+	byte = UDR;
+
+	/* at this point uart_receive_callback should be non-null */
+	uart_receive_callback(byte);
+}
+
+void uart_on_receive(void (*receive_cb)(uint8_t byte))
+{
+	if (!receive_cb) {
+		/* disable reception */
+		UCSRB &= ~((1 << RXCIE) | (1 << RXEN));
+	} else {
+		/* allow reception */
+		UCSRB |= (1 << RXCIE) | (1 << RXEN);
+	}
+
+	uart_receive_callback = receive_cb;
+}
+
+void uart_send(uint8_t *data, size_t len)
+{
+	for (size_t i = 0; i < len; i++) {
+		while ((UCSRA & (1 << UDRE)) == 0) {
+			;;
+		}
+
+		UDR = data[i];
+	}
+}
+
+void uart_init(uint16_t baud_prescale)
+{
+	UCSRB |= (1 << TXEN);
+	UCSRC |= (1 << UCSZ0) | (1 << UCSZ1);
+
+	UBRRH = (baud_prescale >> 8);
+	UBRRL = baud_prescale;
+}
+

--- a/mcu/attiny_x313/uart.h
+++ b/mcu/attiny_x313/uart.h
@@ -1,0 +1,32 @@
+/*
+ * Part of the Conic project - robot arm controller
+ *
+ * ATtiny2313/4313 UART.
+ *
+ * See LICENSE.md for licensing information
+ * Roman Luitko, 2020
+ */
+
+#ifndef MCU_ATTINY_X313_UART_H
+#define MCU_ATTINY_X313_UART_H
+
+#include <stdint.h>
+
+/*
+ * Converts human-readable baudrate into int16 UBRR value
+ * TODO: replace this with a more robust formula with proper integer rounding
+ */
+#define AVR_BAUD(baud)		(((F_CPU / ((baud) * 16UL))) - 1)
+
+#define UART_BAUD_9600		AVR_BAUD(9600UL)
+#define UART_BAUD_14400		AVR_BAUD(14400UL)
+#define UART_BAUD_19200		AVR_BAUD(19200UL)
+#define UART_BAUD_38400		AVR_BAUD(38400UL)
+#define UART_BAUD_57600		AVR_BAUD(57600UL)
+#define UART_BAUD_76800		AVR_BAUD(76800UL)
+#define UART_BAUD_115200	AVR_BAUD(115200UL)
+
+void uart_init(uint16_t baud_prescale);
+
+#endif
+


### PR DESCRIPTION
Unusable at this point, but may actually work with new joint system. Main limitation is RAM size - 128 bytes, but servo system is actually quite compact and I think it'll be possible to control at least 6 servos. Also this introduces some duplication since AVR drivers are mostly same across different chips and differences are minor enough to be preprocessed. But I think it's just cool to squish a firmware to this extreme limits.